### PR TITLE
Passed request as an argument into invite_accepted signal

### DIFF
--- a/invitations/views.py
+++ b/invitations/views.py
@@ -178,7 +178,7 @@ def accept_invitation(invitation, request, signal_sender):
     invitation.accepted = True
     invitation.save()
 
-    invite_accepted.send(sender=signal_sender, email=invitation.email)
+    invite_accepted.send(sender=signal_sender, email=invitation.email, request=request)
 
     get_invitations_adapter().add_message(
         request,

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -178,7 +178,10 @@ def accept_invitation(invitation, request, signal_sender):
     invitation.accepted = True
     invitation.save()
 
-    invite_accepted.send(sender=signal_sender, email=invitation.email, request=request)
+    invite_accepted.send(
+        sender=signal_sender, 
+        email=invitation.email, 
+        request=request)
 
     get_invitations_adapter().add_message(
         request,

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -177,12 +177,10 @@ class AcceptInvite(SingleObjectMixin, View):
 def accept_invitation(invitation, request, signal_sender):
     invitation.accepted = True
     invitation.save()
-
     invite_accepted.send(
-        sender=signal_sender, 
-        email=invitation.email, 
+        sender=signal_sender,
+        email=invitation.email,
         request=request)
-
     get_invitations_adapter().add_message(
         request,
         messages.SUCCESS,


### PR DESCRIPTION
The signal invite_accepted wasn't working due to request not being passed as an argument and the example provided in the signals file wasn't working as well, more details listed below.

https://github.com/bee-keeper/django-invitations/issues/116

I've simply pass request as an argument, all tests seem to be working fine.

Django version used was 1.11