### PR TITLE
French translation

### DIFF
--- a/invitations/locale/fr/LC_MESSAGES/django.po
+++ b/invitations/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,103 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-02-16 18:16+0100\n"
+"PO-Revision-Date: 2020-02-16 18:57+0100\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.2.1\n"
+
+#: base_invitation.py:9
+msgid "accepted"
+msgstr "acceptée"
+
+#: base_invitation.py:10
+msgid "key"
+msgstr "clef"
+
+#: base_invitation.py:11
+msgid "sent"
+msgstr "envoyée"
+
+#: forms.py:31
+msgid "This e-mail address has already been invited."
+msgstr "Cette adresse e-mail a déjà reçu une invitation."
+
+#: forms.py:33
+msgid "This e-mail address has already accepted an invite."
+msgstr "Cette adresse e-mail a déjà accepté une invitation."
+
+#: forms.py:35
+msgid "An active user is using this e-mail address"
+msgstr "Un utilisateur actif utilise cette adresse e-mail"
+
+#: forms.py:51 forms.py:62
+msgid "E-mail"
+msgstr "E-mail"
+
+#: models.py:21
+msgid "e-mail address"
+msgstr "adresse e-mail"
+
+#: models.py:23
+msgid "created"
+msgstr "créée"
+
+#: templates/invitations/email/email_invite_message.txt:3
+#, python-format
+msgid ""
+"\n"
+"\n"
+"Hello,\n"
+"\n"
+"You (%(email)s) have been invited to join %(site_name)s\n"
+"\n"
+"If you'd like to join, please go to %(invite_url)s\n"
+"\n"
+msgstr ""
+"\n"
+"\n"
+"Bonjour,\n"
+"\n"
+"Vous (%(email)s) avez été invité·e à rejoindre %(site_name)s\n"
+"\n"
+"Si vous souhaitez vous inscrire, merci de suivre ce lien: %(invite_url)s\n"
+"\n"
+
+#: templates/invitations/email/email_invite_subject.txt:3
+#, python-format
+msgid "Invitation to join %(site_name)s"
+msgstr "Invitation à rejoindre %(site_name)s"
+
+#: templates/invitations/forms/_invite.html:3
+msgid "Invite"
+msgstr "Inviter"
+
+#: templates/invitations/forms/_invite.html:4
+msgid "Please add an email below. The user will receive an email with instructions."
+msgstr "Merci d'ajouter une adresse e-mail ci-dessous. L'utilisateur recevra un courriel avec des instructions."
+
+#: templates/invitations/forms/_invite.html:9
+msgid "Email"
+msgstr "Email"
+
+#: templates/invitations/messages/invite_accepted.txt:3
+#, python-format
+msgid "Invitation to - %(email)s - has been accepted"
+msgstr "L'invitation envoyée à - %(email)s - a été acceptée"
+
+#: views.py:44
+#, python-format
+msgid "%(email)s has been invited"
+msgstr "%(email)s a été invité·e"


### PR DESCRIPTION
Here is a French translation. This is standard French (from France), not the flavour spoken in Quebec (Canada) where they use neologisms like "courriel" instead of the universal "e-mail".