### PR TITLE
Use gettext instead of ugettext

### DIFF
--- a/invitations/base_invitation.py
+++ b/invitations/base_invitation.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .managers import BaseInvitationManager
 

--- a/invitations/forms.py
+++ b/invitations/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .adapters import get_invitations_adapter
 from .exceptions import AlreadyAccepted, AlreadyInvited, UserRegisteredEmail

--- a/invitations/models.py
+++ b/invitations/models.py
@@ -9,7 +9,7 @@ except ImportError:
 from django.db import models
 from django.utils import timezone
 from django.utils.crypto import get_random_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import signals
 from .adapters import get_invitations_adapter

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -7,7 +7,7 @@ from django.core.validators import validate_email
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, View
 from django.views.generic.detail import SingleObjectMixin
 


### PR DESCRIPTION
ugettext will be removed in Django 4.0.
This change will not work in Python 2.x.