### PR TITLE
Make "inviter" be an raw_id_field in admin

### DIFF
--- a/invitations/admin.py
+++ b/invitations/admin.py
@@ -10,6 +10,7 @@ InvitationAdminChangeForm = get_invitation_admin_change_form()
 
 class InvitationAdmin(admin.ModelAdmin):
     list_display = ('email', 'sent', 'accepted')
+    raw_id_fields = ("inviter",)
 
     def get_form(self, request, obj=None, **kwargs):
         if obj:


### PR DESCRIPTION
Showing the admin form takes very long when creating an invitation via the admin on a site with many users. Adding the `inviter` field under `raw_id_fields` makes things faster.