### PR TITLE
refactor(models): use get_current_site from django shortcuts

### DIFF
--- a/invitations/adapters.py
+++ b/invitations/adapters.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.sites.models import Site
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
@@ -24,11 +23,11 @@ class BaseInvitationsAdapter(object):
         request.session['account_verified_email'] = None
         return ret
 
-    def format_email_subject(self, subject):
+    def format_email_subject(self, subject, context):
         prefix = app_settings.EMAIL_SUBJECT_PREFIX
         if prefix is None:
-            site = Site.objects.get_current()
-            prefix = "[{name}] ".format(name=site.name)
+            site_name = context["site_name"]
+            prefix = "[{name}] ".format(name=site_name)
         return prefix + force_text(subject)
 
     def render_mail(self, template_prefix, email, context):
@@ -40,7 +39,7 @@ class BaseInvitationsAdapter(object):
                                    context)
         # remove superfluous line breaks
         subject = " ".join(subject.splitlines()).strip()
-        subject = self.format_email_subject(subject)
+        subject = self.format_email_subject(subject, context)
 
         bodies = {}
         for ext in ['html', 'txt']:

--- a/invitations/models.py
+++ b/invitations/models.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.conf import settings
-from django.contrib.sites.models import Site
+from django.contrib.sites.shortcuts import get_current_site
 try:
     from django.urls import reverse
 except ImportError:
@@ -40,7 +40,7 @@ class Invitation(AbstractBaseInvitation):
         return expiration_date <= timezone.now()
 
     def send_invitation(self, request, **kwargs):
-        current_site = kwargs.pop('site', Site.objects.get_current())
+        current_site = get_current_site(request)
         invite_url = reverse('invitations:accept-invite',
                              args=[self.key])
         invite_url = request.build_absolute_uri(invite_url)


### PR DESCRIPTION
Use `get_current_site` from `django.contrib.sites.shortcuts` instead of hard coding with the `Site` object for better compatibility with multi sites and non-multi sites django instalations. As said in the docs of the function `def get_current_site(request):`

> Check if contrib.sites is installed and return either the current
>     ``Site`` object or a ``RequestSite`` object based on the request