### PR TITLE
allow Invitation key to be passed to the redirected url

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,6 +8,15 @@ Generic Invitation flow:
 * Privileged user invites prospective user by email (via either Django admin, form post, JSON post or programmatically)
 * User receives invitation email with confirmation link
 * User clicks link and is redirected to a preconfigured url (default is accounts/signup)
+    * This should take the form off 
+
+.. code-block:: python
+        re_path(
+        r"^accounts/signup/(?P<key>\w+)/?$",
+        views.signup,
+        name="account_signup",
+    ),
+    
 
 Allauth Invitation flow:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,7 +11,8 @@ Generic Invitation flow:
     * This should take the form off
 
 .. code-block:: python
-        re_path(
+
+   re_path(
         r"^accounts/signup/(?P<key>\w+)/?$",
         views.signup,
         name="account_signup",

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,7 +8,7 @@ Generic Invitation flow:
 * Privileged user invites prospective user by email (via either Django admin, form post, JSON post or programmatically)
 * User receives invitation email with confirmation link
 * User clicks link and is redirected to a preconfigured url (default is accounts/signup)
-    * This should take the form off 
+    * This should take the form off
 
 .. code-block:: python
         re_path(
@@ -16,7 +16,7 @@ Generic Invitation flow:
         views.signup,
         name="account_signup",
     ),
-    
+
 
 Allauth Invitation flow:
 

--- a/invitations/views.py
+++ b/invitations/views.py
@@ -164,7 +164,7 @@ class AcceptInvite(SingleObjectMixin, View):
 
         get_invitations_adapter().stash_verified_email(self.request, invitation.email)
 
-        return redirect(self.get_signup_redirect())
+        return redirect(self.get_signup_redirect(), key=invitation.key)
 
     def get_object(self, queryset=None):
         if queryset is None:


### PR DESCRIPTION
Allow the Invitation key to passed to the redirected for further inspection. This is used to implement a pairing model in my case.