### PR TITLE
Set default primary key, no migration needed

### DIFF
--- a/invitations/apps.py
+++ b/invitations/apps.py
@@ -4,5 +4,6 @@ from django.apps import AppConfig
 class Config(AppConfig):
     """Config."""
 
+    default_auto_field = "django.db.models.AutoField"
     name = "invitations"
     label = "invitations"


### PR DESCRIPTION
Fixes issue #205, while it might be better in the future to include the migration, since default settings from Django is setting the auto_field:
`DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'`