### PR TITLE
Remove mention of sites framework from docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,13 +17,12 @@ Installation
 
        python -m pip install django-invitations
 
-2. Add "django.contrib.sites" and "invitations" to INSTALLED_APPS
+2. Add "invitations" to INSTALLED_APPS
 
    .. code-block:: python
 
         INSTALLED_APPS = [
             ...
-            "django.contrib.sites",
             "invitations",
             ...
         ]
@@ -31,15 +30,6 @@ Installation
 .. note:: **Allauth support**
 
    For allauth support ``invitations`` must come after ``allauth`` in the INSTALLED_APPS
-
-
-3. Make sure you have SITE_ID defined in settings:
-
-   .. code-block:: python
-
-        ...
-        SITE_ID = 1
-        ...
 
 3. Add invitations urls to your urlpatterns:
 


### PR DESCRIPTION
From what I can tell, [Django's sites framework](https://docs.djangoproject.com/en/4.2/ref/contrib/sites/) is no longer required now that #150 has been merged. So, the references to the sites framework in the installation docs can be removed.

It's worth noting that django-allauth still requires the sites framework, but [django-allauth's own docs](https://django-allauth.readthedocs.io/en/latest/installation.html#django) already mention this.