### PR TITLE
[#203] Add related_name to avoid conflicts when subclassing.

### DIFF
--- a/invitations/base_invitation.py
+++ b/invitations/base_invitation.py
@@ -15,6 +15,8 @@ class AbstractBaseInvitation(models.Model):
         null=True,
         blank=True,
         on_delete=models.CASCADE,
+        related_name="%(app_label)s_%(class)ss",
+        related_query_name="%(app_label)s_%(class)s",
     )
 
     objects = BaseInvitationManager()

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -48,6 +48,19 @@ class TestInvitationModel:
         )
         assert invitation_a.key_expired() is False
 
+    def test_invitation_related_name(self, sent_invitation_by_user_a):
+        user = sent_invitation_by_user_a.inviter
+        assert user.invitations_invitations.all()
+        assert user.invitations_invitations.count() == 1
+
+    def test_invitation_related_query_name(self, sent_invitation_by_user_a):
+        assert (
+            Invitation.objects.filter(
+                inviter__invitations_invitation__id=sent_invitation_by_user_a.pk
+            ).count()
+            == 1
+        )
+
 
 class TestInvitationsAdapter:
     def test_fetch_adapter(self):


### PR DESCRIPTION
I am not sure if the issue should be closed, since it would be better to prevent `invitations.Invitation` in the DB altogether, when a custom model is used.