### PR TITLE
Pass through redirect query arg

### DIFF
--- a/test_allauth_settings.py
+++ b/test_allauth_settings.py
@@ -22,3 +22,5 @@ AUTHENTICATION_BACKENDS = (
 ACCOUNT_ADAPTER = "invitations.models.InvitationsAdapter"
 
 MIDDLEWARE.append("allauth.account.middleware.AccountMiddleware")  # noqa: F405
+
+STATIC_URL = ""

--- a/tests/allauth/test_allauth.py
+++ b/tests/allauth/test_allauth.py
@@ -210,8 +210,7 @@ class TestAllAuthIntegration:
 
         assert resp.status_code == 302
         assert (
-            resp.url
-            == f"{app_settings.LOGIN_REDIRECT}?{REDIRECT_FIELD_NAME}={next_}"
+            resp.url == f"{app_settings.LOGIN_REDIRECT}?{REDIRECT_FIELD_NAME}={next_}"
         )
 
     def test_fetch_adapter(self):


### PR DESCRIPTION
Fixes #231.

Pass through a `next=...` query parameter to the signup and login views.

The docs for [`SIGNUP_REDIRECT`](https://github.com/jazzband/django-invitations/blob/master/docs/configuration.rst#signup_redirect) and [`LOGIN_REDIRECT`](https://github.com/jazzband/django-invitations/blob/master/docs/configuration.rst#login_redirect) indicate they should be a URL _name_, the default values for these settings are URL names, and the tests for the allauth backend do not override those options and so expect a URL name.

But the [tests for the basic backend](https://github.com/jazzband/django-invitations/blob/a81617da3415fe5f807e575c8d81e6c38b636592/tests/basic/tests.py) override that option with a direct URL:

```python
        settings.INVITATIONS_LOGIN_REDIRECT = "/login-url/"
        ...
        settings.INVITATIONS_LOGIN_REDIRECT = "/login-url/"
        ...
        settings.INVITATIONS_SIGNUP_REDIRECT = "/signup-url/"
        ...
        settings.INVITATIONS_SIGNUP_REDIRECT = "/non-existent-url/"
        ...
        settings.INVITATIONS_SIGNUP_REDIRECT = "/non-existent-url/"
        ...
    @override_settings(INVITATIONS_SIGNUP_REDIRECT="/non-existent-url/")
    ...
        settings.INVITATIONS_LOGIN_REDIRECT = "/login-url/"
```

Which is why I do this in this PR:

```python
        try:
            signup_redirect = reverse(app_settings.SIGNUP_REDIRECT)
        except NoReverseMatch:
            signup_redirect = app_settings.SIGNUP_REDIRECT
        ...
        try:
            login_redirect = reverse(app_settings.LOGIN_REDIRECT)
        except NoReverseMatch:
            login_redirect = app_settings.LOGIN_REDIRECT
```

Fixing this may not be backwards compatible with existing users. It is also best left for a separate discussion, so for this PR I allowed for both options.

I also removed the walrus operator in a separate commit, so once we drop support for Python 3.7 we can revert that single commit to use the walrus operator.