### PR TITLE
Allow subclassing InvitationsAdapter

### DIFF
--- a/invitations/adapters.py
+++ b/invitations/adapters.py
@@ -112,10 +112,7 @@ class BaseInvitationsAdapter:
 
 def get_invitations_adapter():
     # Compatibility with legacy allauth only version.
-    LEGACY_ALLAUTH = (
-        hasattr(settings, "ACCOUNT_ADAPTER")
-        and settings.ACCOUNT_ADAPTER == "invitations.models.InvitationsAdapter"
-    )
+    LEGACY_ALLAUTH = hasattr(settings, "ACCOUNT_ADAPTER")
     if LEGACY_ALLAUTH:
         # defer to allauth
         from allauth.account.adapter import get_adapter

--- a/invitations/models.py
+++ b/invitations/models.py
@@ -75,22 +75,21 @@ class Invitation(AbstractBaseInvitation):
 
 # here for backwards compatibility, historic allauth adapter
 if hasattr(settings, "ACCOUNT_ADAPTER"):
-    if settings.ACCOUNT_ADAPTER == "invitations.models.InvitationsAdapter":
-        from allauth.account.adapter import DefaultAccountAdapter
-        from allauth.account.signals import user_signed_up
+    from allauth.account.adapter import DefaultAccountAdapter
+    from allauth.account.signals import user_signed_up
 
-        class InvitationsAdapter(DefaultAccountAdapter):
-            def is_open_for_signup(self, request):
-                if hasattr(request, "session") and request.session.get(
-                    "account_verified_email",
-                ):
-                    return True
-                elif app_settings.INVITATION_ONLY is True:
-                    # Site is ONLY open for invites
-                    return False
-                else:
-                    # Site is open to signup
-                    return True
+    class InvitationsAdapter(DefaultAccountAdapter):
+        def is_open_for_signup(self, request):
+            if hasattr(request, "session") and request.session.get(
+                "account_verified_email",
+            ):
+                return True
+            elif app_settings.INVITATION_ONLY is True:
+                # Site is ONLY open for invites
+                return False
+            else:
+                # Site is open to signup
+                return True
 
-            def get_user_signed_up_signal(self):
-                return user_signed_up
+        def get_user_signed_up_signal(self):
+            return user_signed_up

--- a/test_allauth_adapters.py
+++ b/test_allauth_adapters.py
@@ -1,0 +1,10 @@
+from invitations.models import InvitationsAdapter
+
+
+class TestInvitationsAdapter(InvitationsAdapter):
+    """Class used to test that subclasses to InvitationsAdapter work as
+    expected
+
+    """
+
+    pass

--- a/test_allauth_settings.py
+++ b/test_allauth_settings.py
@@ -19,7 +19,7 @@ AUTHENTICATION_BACKENDS = (
     "allauth.account.auth_backends.AuthenticationBackend",
 )
 
-ACCOUNT_ADAPTER = "invitations.models.InvitationsAdapter"
+ACCOUNT_ADAPTER = "test_allauth_adapters.TestInvitationsAdapter"
 
 MIDDLEWARE.append("allauth.account.middleware.AccountMiddleware")  # noqa: F405
 


### PR DESCRIPTION
Previously, the code would check to see if ACCOUNT_ADAPTER equalled "invitations.models.InvitationsAdapter". But this would cause it to reject subclasses of InvitationsAdapter. Instead, it is enough to check to see if ACCOUNT_ADAPTER setting exists, as this setting is meant for django-allauth.

I would like someone to review this, to check to see if I'm missing something.